### PR TITLE
Upgrade azurerm provider to version 2.22

### DIFF
--- a/init.tf
+++ b/init.tf
@@ -1,5 +1,5 @@
 provider "azurerm" {
-  version = "2.0"
+  version = "2.22"
   features {}
 }
 


### PR DESCRIPTION
Upgrade azurerm provider to version 2.22 in order to import the `min_tls_version` attribute for the `azurerm_storage_account` resource type